### PR TITLE
Disable Collider Mods

### DIFF
--- a/Assets/Prefabs/Player_WithModel.prefab
+++ b/Assets/Prefabs/Player_WithModel.prefab
@@ -673,7 +673,7 @@ GameObject:
   m_Component:
   - 4: {fileID: 444774}
   - 135: {fileID: 13552818}
-  m_Layer: 9
+  m_Layer: 11
   m_Name: DisableCollider
   m_TagString: Disabler
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/NPC/SpawnVolume.cs
+++ b/Assets/Scripts/NPC/SpawnVolume.cs
@@ -151,7 +151,6 @@ public class SpawnVolume : MonoBehaviour {
         float randomFish = Random.value * total;
         for (int i= 0; i < probabilities.Length; i++) {
             if (randomFish < probabilities[i]) {
-                // Debug.Log(i);
                 return i;
             }
             else {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Fish
+  - Disabler
   layers:
   - Default
   - TransparentFX
@@ -16,7 +17,7 @@ TagManager:
   - 
   - Light (Absorbable)
   - Light (Collider)
-  - 
+  - SpawnVolume
   - 
   - 
   - 


### PR DESCRIPTION
Added layers - spawnVolume and Disabler
This prevents fish from getting absorbed when hitting an outer sphere collider