### PR TITLE
Updated checkpoints

### DIFF
--- a/Assets/Scenes/Archive/Level 2/Level 2.1 - Intro.unity
+++ b/Assets/Scenes/Archive/Level 2/Level 2.1 - Intro.unity
@@ -905,7 +905,7 @@ Transform:
   m_LocalScale: {x: 446.86633, y: 178.26117, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 5
 --- !u!23 &199756477
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -2598,6 +2598,56 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 802d4c0bd857348e69b91324984f3e54, type: 3}
   m_IsPrefabParent: 0
+--- !u!1001 &549353720
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 104.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -2.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 123206, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_Name
+      value: Checkpoint (Save + transition)
+      objectReference: {fileID: 0}
+    - target: {fileID: 11414324, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: changeScene
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1001 &549609781
 Prefab:
   m_ObjectHideFlags: 0
@@ -2652,6 +2702,14 @@ Prefab:
     - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
       propertyPath: m_LocalScale.z
       value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 11414324, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: changeScene
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11414324, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: infiniteEnergy
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
@@ -2887,7 +2945,7 @@ Transform:
   - {fileID: 1935185280}
   - {fileID: 503608897}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 12
 --- !u!1001 &658546317
 Prefab:
   m_ObjectHideFlags: 0
@@ -4771,7 +4829,7 @@ Transform:
   - {fileID: 1294204477}
   - {fileID: 1462307462}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 11
 --- !u!1 &1012999004
 GameObject:
   m_ObjectHideFlags: 0
@@ -7233,7 +7291,7 @@ Transform:
   - {fileID: 1017249461}
   - {fileID: 1055855479}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 6
 --- !u!1001 &1415058696
 Prefab:
   m_ObjectHideFlags: 0
@@ -7941,6 +7999,52 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1522634680}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &1527418936
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 15.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -2.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 434496, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 123206, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+      propertyPath: m_Name
+      value: Checkpoint (Save only)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 05d9fc8758ff84fd087eead2438110c6, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &1536146227
 GameObject:
   m_ObjectHideFlags: 0
@@ -9206,7 +9310,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 424626, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
       propertyPath: m_LocalRotation.x
-      value: 0.15093932
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 424626, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
       propertyPath: m_LocalRotation.y
@@ -9218,7 +9322,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 424626, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
       propertyPath: m_LocalRotation.w
-      value: 0.98854303
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 424626, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
       propertyPath: m_RootOrder
@@ -9242,13 +9346,14 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 11456182, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
       propertyPath: disableCheckpoints
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 10884036, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
       propertyPath: m_Range
       value: 100
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 11421534, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
   m_IsPrefabParent: 0
 --- !u!1 &1776238067
@@ -10546,7 +10651,7 @@ Transform:
   m_Children:
   - {fileID: 918303572}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 9
 --- !u!114 &1935136148
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10573,7 +10678,7 @@ MonoBehaviour:
   canAbsorb: 0
   absorptionRate: 15
   defaultEnergy: 10
-  debugInfiniteLight: 0
+  infiniteEnergy: 0
 --- !u!1 &1935185279
 GameObject:
   m_ObjectHideFlags: 0
@@ -10898,7 +11003,7 @@ Transform:
   - {fileID: 1680352358}
   - {fileID: 1450178930}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 7
 --- !u!1001 &2047013490
 Prefab:
   m_ObjectHideFlags: 0
@@ -11188,7 +11293,7 @@ Transform:
   - {fileID: 100461325}
   - {fileID: 207110519}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 10
 --- !u!1 &2078769822
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Archive/Level 2/Level 2.3 - Jellyfish Fields.unity
+++ b/Assets/Scenes/Archive/Level 2/Level 2.3 - Jellyfish Fields.unity
@@ -2002,6 +2002,10 @@ Prefab:
       propertyPath: defaultEnergy
       value: 15
       objectReference: {fileID: 0}
+    - target: {fileID: 198018, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 11421534, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
     - {fileID: 11437706, guid: eea3edfe73050394987fb0cbdc1dee62, type: 2}
@@ -2364,6 +2368,10 @@ Prefab:
     - target: {fileID: 11451590, guid: 9972ffb20fae6a4409bacb042503b3fd, type: 2}
       propertyPath: zPosition
       value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 142196, guid: 9972ffb20fae6a4409bacb042503b3fd, type: 2}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 9972ffb20fae6a4409bacb042503b3fd, type: 2}

--- a/Assets/Scripts/Camera/SmoothCamera.cs
+++ b/Assets/Scripts/Camera/SmoothCamera.cs
@@ -19,6 +19,11 @@ public class SmoothCamera : MonoBehaviour
 
     private Vector2 velocity = Vector2.zero;
 
+    void Awake()
+    {
+       DontDestroyOnLoad(this.transform.gameObject); 
+    }
+
     void FixedUpdate()
     {
         if (target)

--- a/Assets/Scripts/Light/LightEnergy.cs
+++ b/Assets/Scripts/Light/LightEnergy.cs
@@ -9,7 +9,7 @@ public class LightEnergy
     private float currentEnergy;
 
     private GameObject gameObject;
-    
+
     private bool debugInfiniteLight = false;
 
     public delegate void LightChangedHandler(float currentLight);
@@ -27,7 +27,7 @@ public class LightEnergy
         this.debugInfiniteLight = debugInfiniteLight;
         LightChanged(this.currentEnergy);
     }
-    
+
     /// <summary>
     /// Adds the given amount of light energy
     /// </summary>
@@ -50,7 +50,7 @@ public class LightEnergy
         {
             return lightToRemove;
         }
-                            
+
         // Stores the actual amount of light depleted from this energy source
         float actualLightRemoved = lightToRemove;
 
@@ -72,11 +72,11 @@ public class LightEnergy
         if (this.currentEnergy <= 0)
         {
             LightDepleted();
-            if (this.gameObject.name != "Player")
+            if (this.gameObject.tag == "Player")
             {
                 // stops players inert movement
-                this.gameObject.GetComponent<Rigidbody>().drag = 10;                
-            }
+                this.gameObject.GetComponent<Rigidbody>().drag = 10;
+            }           
         }
 
         return actualLightRemoved;

--- a/Assets/Scripts/Light/LightSource.cs
+++ b/Assets/Scripts/Light/LightSource.cs
@@ -19,7 +19,7 @@ public class LightSource : MonoBehaviour
     public float defaultEnergy = 10;
 
     [Tooltip("If true, the light source has infinite energy")]
-    public bool debugInfiniteLight = false;
+    public bool infiniteEnergy = false;
 
     // The light sources this GameObject is touching
     private List<LightSource> lightsInContact = new List<LightSource>();
@@ -28,7 +28,7 @@ public class LightSource : MonoBehaviour
 
     public virtual void Awake()
     {
-        lightEnergy = new LightEnergy(defaultEnergy, gameObject, debugInfiniteLight);
+        lightEnergy = new LightEnergy(defaultEnergy, gameObject, infiniteEnergy);
     }
 
     public virtual void Update()

--- a/Assets/Scripts/Managers/Checkpoint.cs
+++ b/Assets/Scripts/Managers/Checkpoint.cs
@@ -3,9 +3,13 @@ using UnityEngine.SceneManagement;
 
 public class Checkpoint : LightSource
 {
+    [Tooltip("If set to true, this checkpoint will teleport player to the next scene")]
+    public bool changeScene = false;
+    
     public override void Awake()
-    {
+    {       
         base.Awake(); // call parent LightSource Awake() first
+        this.infiniteEnergy = true; // override default LightSource value
     }
 
     public override void OnTriggerEnter(Collider other)
@@ -14,13 +18,28 @@ public class Checkpoint : LightSource
         {
             int currentLevel = other.gameObject.GetComponent<Player>().CurrentLevel;
             PlayerData data = new PlayerData();
-            data.playerPosition = DataManager.Vector3ToString(other.gameObject.transform.position);
+            
+            if (changeScene)
+            {
+                // if checkpoint changes scene, save values for the new scene
+                data.playerPosition = DataManager.Vector3ToString(new Vector3(0, 0, 0));
+                data.levelID = currentLevel + 1;    
+            } 
+            else
+            {
+                data.playerPosition = DataManager.Vector3ToString(other.gameObject.transform.position);
+                data.levelID = currentLevel;    
+            }            
+            
             data.playerRotation = DataManager.Vector3ToString(other.gameObject.transform.localEulerAngles);
             data.playerScale = DataManager.Vector3ToString(other.gameObject.transform.localScale);
-            data.playerEnergy = other.gameObject.GetComponent<Player>().LightEnergy.CurrentEnergy;
-            data.levelID = currentLevel;
-            DataManager.SaveFile(data);
-            ChangeLevel(currentLevel + 1);            
+            data.playerEnergy = other.gameObject.GetComponent<Player>().LightEnergy.CurrentEnergy;            
+            DataManager.SaveFile(data);    
+            
+            if (changeScene)
+            {
+                ChangeLevel(currentLevel + 1);
+            }        
         }
     }
     

--- a/Assets/Scripts/Managers/DataManager.cs
+++ b/Assets/Scripts/Managers/DataManager.cs
@@ -15,8 +15,8 @@ public static class DataManager
 
     /// <summary>
     /// Saves last player position on the current level on the disk
-    /// NOTE: MAC file location:  /Users/USERNAME/Library/Application Support/FJFCompany/Space Explorer/ 
-    ///       PC file location: C:\Users\USERNAME\AppData\LocalLow\FJFCompany\Space Explorer
+    /// NOTE: MAC file location:  /Users/USERNAME/Library/Application Support/FJFTeam/Space Explorer/ 
+    ///       PC file location: C:\Users\USERNAME\AppData\LocalLow\FJFTeam\Space Explorer
     /// </summary>
     public static void SaveFile(PlayerData data)
     {

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -54,14 +54,21 @@ public class Player : LightSource
     public override void Awake()
     {
        base.Awake(); // call parent LightSource Awake() first
-       transform = GetComponent<Transform>();
-       rigidbody = GetComponent<Rigidbody>();
-       movement = new PlayerMovement(massEjectionTransform, lightBallPrefab, thrustForce, thrustEnergyCost, transform, rigidbody, this.LightEnergy);
-       lightToggle = new PlayerLightToggle(transform.Find("LightsToToggle").gameObject, defaultLightStatus, this, minimalEnergyRestrictionToggleLights);
+       this.transform = GetComponent<Transform>();
+       this.rigidbody = GetComponent<Rigidbody>();       
+       this.movement = new PlayerMovement(massEjectionTransform, lightBallPrefab, thrustForce, thrustEnergyCost, transform, rigidbody, this.LightEnergy);
+       this.lightToggle = new PlayerLightToggle(transform.Find("LightsToToggle").gameObject, defaultLightStatus, this, minimalEnergyRestrictionToggleLights);
        this.LightEnergy.LightDepleted += OnLightDepleted;
        this.isDead = false;
        this.currentLevel = SceneManager.GetActiveScene().buildIndex;
+       DontDestroyOnLoad(this.transform.gameObject);
        LoadGame();
+    }
+    
+    void OnLevelWasLoaded(int level) 
+    {
+        Debug.Log("Scene " + level + " is loaded!");
+        this.transform.position = new Vector3(0, 0, 0); 
     }
 
     // Update is called once per frame
@@ -124,8 +131,15 @@ public class Player : LightSource
     {              
         PlayerData data = DataManager.LoadFile();
         
-        if (data != null && data.levelID == this.currentLevel && !disableCheckpoints)
+        if (data != null && !disableCheckpoints)
         {
+            if (data.levelID != this.currentLevel) 
+            {
+                if (SceneManager.sceneCountInBuildSettings > data.levelID)
+                {
+                    SceneManager.LoadScene(data.levelID, LoadSceneMode.Single);
+                }                    
+            }
             transform.position = DataManager.Vector3FromString(data.playerPosition);
             transform.localEulerAngles = DataManager.Vector3FromString(data.playerRotation);
         } 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,10 +6,10 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/Level 2/Level 2.1 - Intro.unity
-  - enabled: 1
+    path: Assets/Scenes/Archive/Level 2/Level 2.1 - Intro.unity
+  - enabled: 0
     path: Assets/Scenes/Level 2/Level 2.2 - Volcanoes and Whirlpool.unity
   - enabled: 1
-    path: Assets/Scenes/Level 2/Level 2.3 - Jellyfish Fields.unity
+    path: Assets/Scenes/Archive/Level 2/Level 2.3 - Jellyfish Fields.unity
   - enabled: 1
-    path: Assets/Scenes/Level 2/Level 2.4 - Final Cave.unity
+    path: Assets/Scenes/Archive/Level 2/Level 2.4 - Final Cave.unity


### PR DESCRIPTION
- [x] Checkpoints have a new option "Switch Scene", if checked the picked checkpoint will load the next scene (specified in build settings)
- [x] Player object & Main camera now persist across scenes (aka only the first scene needs a player & camera objects, all the following scenes will use the objects generates from the previous scene
- [x] Fixed some bugs with player and checkpoints, renamed stuff for consistency

>**Note**: Checkpoint has infinite energy true by default and next scene false by default
>
>**Note 2**: If game is loaded from the latest checkpoint, the scene will switch the one stored, otherwise player will be places near his latest checkpoint on the current scene.
>
>**Note 3**: To test functionality use Scene 2.1 from the Archive 